### PR TITLE
Refactor Element

### DIFF
--- a/include/tpcc/element.h
+++ b/include/tpcc/element.h
@@ -69,13 +69,19 @@ public:
    * The Element extends along `k` integer coordinates, which are mapped through #directions to the `n` integer coordinates of the complex.
    * This function maps the local coordinate direction of the Element to the global direction in the chain complex.
    */
-  constexpr Sint along(Tint index) const
+  constexpr Tint along_direction(Tint index) const
   { return n-1-directions.in(index); }
 
   /// The coordinates in the `k`-dimensional mesh
-  constexpr Sint coordinate_along(Tint index) const
-  { return positions[along(index)]; }
-  /**
+  constexpr Sint along_coordinate(Tint index) const
+  { return positions[along_direction(index)]; }
+
+  constexpr Tint across_direction(Tint index) const
+  { return n-1-directions.out(index); }
+
+  /// The coordinate in the `k`-dimensional mesh
+  constexpr Sint across_coordinate(Tint index) const
+  { return positions[across_direction(index)]; }  /**
    * \brief Function for printing the data stored in the element.
    *
    * \note This function is also used in the consistency tests,
@@ -86,10 +92,10 @@ public:
   {
     os << " (";
     for (Tint i=0;i<k;++i)
-      os << along(i);
+      os << (unsigned int) along_direction(i);
     os << ':';
     for (Tint i=0;i<n-k;++i)
-      os << n-1-directions.out(i);
+      os << (unsigned int) across_direction(i);
     os << ' ';
     for (unsigned int i=0;i<n-1;++i)
       os << positions[i] << ',';
@@ -110,7 +116,7 @@ public:
   {
     Tint i2 = index/2;  // The direction index out of k
     Tint im = index%2;  // Lower or upper boundary in this direction?
-    Tint gi = along(i2); // The global direction out of n belonging to index
+    Tint gi = along_direction(i2); // The global direction out of n belonging to index
     Combination<n,k-1> combi = directions.eliminate(i2);
     std::array<Sint, n> new_positions = positions;
     if (im == 1)

--- a/include/tpcc/element.h
+++ b/include/tpcc/element.h
@@ -9,22 +9,23 @@ namespace TPCC
  * \brief Tensor coordinates for a facet of dimension `k` in the complex of dimension `n`.
  *
  * Each element is characterized by its orientation and its
- * position in the complex. The orientation or #direction is
+ * position in the complex. The orientation is
  * described by a combination of `k` coordinates which span the
  * element. It has no extension across these coordinates.
  *
- * The set of elements for a fixed combination of #directions
- * consists of slices of dimension `k` through the complex. These
- * slices are indexed by the coordinates <b>not</b> spanning the
- * elements. These indices are stored in
- * #position_across. Finally, they are numbered within the
- * `k`-dimensional slice in the entry #position_along. Both fields
- * are vectors of integer coordinates in all coordinate
- * directions.
+ * The coordinates of an Element are stored in the array #positions. Its length is `n`and
+ * it is ordered the same way as the coordinates in the whole chain complex. Thus, the first entry
+ * in there refers to the 'global' first coordinate, no matter whether this is a coordinate direction
+ * in which the Element extends. These global coordinates are accessed by operator[]().
  *
- * The fields #position_along and #position_across are indexed by
- * the combination of #directions and its complement,
- * respectively.
+ * The `k` local coordinates of the Element in the directions in which it extends are accessed
+ * by along_coordinate(). Their global counterparts are numbered by along_direction().
+ *
+ * The `n-k` coordinates orthogonal to the element are accessed by across_coordinate(). The
+ * corresponding global directions are numbered by across_direction().
+ *
+ * An imbortant feature of Element is that you can obtain an Element object for each of its boundary
+ * elements through facet().
  *
  * \tparam n: The dimension of the tensor chain complex
  * \tparam k: The dimension of this element
@@ -41,7 +42,7 @@ class Element
    * the directions are actually not the value in the combination or its complement.
    * The index `i` returned by the combination is immediately replaced by `n-1-i`.
    */
-  Combination<n,k> directions;
+  Combination<n,k> orientation;
   /// The integer coordinates within the `n`-dimensional complex
   std::array<Sint, n> positions;
 
@@ -49,7 +50,7 @@ public:
   /// Constructor with both data elements
   template <typename T>
   Element(const Combination<n,k>& combi, const std::array<T,n>& pos)
-    : directions(combi), positions(pos) {}
+    : orientation(combi), positions(pos) {}
 
   /// The number of facets in the boundary of this object
   static constexpr Tint n_facets()
@@ -57,31 +58,37 @@ public:
 
   /// The index of the combination enumerating directions
   constexpr Tint direction_index () const
-  { return Combinations<n,k>::index(directions); }
+  { return Combinations<n,k>::index(orientation); }
 
   /// The coordinates in the `n`-dimensional chain complex
   constexpr Sint operator[] (Tint index) const
   { return positions[index]; }
 
   /**
-   * \brief The coordinate direction out of `n` in the complex for the coordinate direction out of `k` of the element
+   * \brief Mapping from local to global coordinate directions.
    *
-   * The Element extends along `k` integer coordinates, which are mapped through #directions to the `n` integer coordinates of the complex.
+   * The Element extends along `k` integer coordinates, which are mapped through #orientation
+   * to the `n` integer coordinates of the complex.
    * This function maps the local coordinate direction of the Element to the global direction in the chain complex.
    */
   constexpr Tint along_direction(Tint index) const
-  { return n-1-directions.in(index); }
+  { return n-1-orientation.in(index); }
 
-  /// The coordinates in the `k`-dimensional mesh
+  /// The coordinates in the `k`-dimensional element
   constexpr Sint along_coordinate(Tint index) const
   { return positions[along_direction(index)]; }
 
+  /**
+   * \brief Mapping of orthogonal coordinate directions to global.
+   */
   constexpr Tint across_direction(Tint index) const
-  { return n-1-directions.out(index); }
+  { return n-1-orientation.out(index); }
 
-  /// The coordinate in the `k`-dimensional mesh
+  /// The position of the element orthogonal to its extension
   constexpr Sint across_coordinate(Tint index) const
-  { return positions[across_direction(index)]; }  /**
+  { return positions[across_direction(index)]; }
+
+  /**
    * \brief Function for printing the data stored in the element.
    *
    * \note This function is also used in the consistency tests,
@@ -117,7 +124,7 @@ public:
     Tint i2 = index/2;  // The direction index out of k
     Tint im = index%2;  // Lower or upper boundary in this direction?
     Tint gi = along_direction(i2); // The global direction out of n belonging to index
-    Combination<n,k-1> combi = directions.eliminate(i2);
+    Combination<n,k-1> combi = orientation.eliminate(i2);
     std::array<Sint, n> new_positions = positions;
     if (im == 1)
       ++new_positions[gi];

--- a/include/tpcc/lexicographic.h
+++ b/include/tpcc/lexicographic.h
@@ -132,31 +132,31 @@ Lexicographic<n,k,Bint,Sint,Tint>::operator[] (Bint index) const
       across[i] = index % fdim;
       index /= fdim;
     }
-  return Element<n,k,Sint,Tint>{combination, along, across};
+  //return Element<n,k,Sint,Tint>{combination, along, across};
 }
 
 template <int n, int k, typename Bint, typename Sint, typename Tint>
 Bint
 Lexicographic<n,k,Bint,Sint,Tint>::index (const value_type& e) const
 {
-  Bint ci = Combinations<n,k>::index(e.directions);
+  Bint ci = e.direction_index();
   Bint result = 0;
-  for (unsigned int i=0;i<ci;++i)
-    result += block_sizes[i];  
+//  for (unsigned int i=0;i<ci;++i)
+//    result += block_sizes[i];
 
-  Bint factor = 1;
-  for (unsigned int i=0;i<k;++i)
-    {
-      Tint fdim = dimensions[e.directions.in(i)];
-      result += e.position_along[i] *factor;
-      factor *= fdim;
-    } 
-  for (unsigned int i=0;i<n-k;++i)
-    {
-      Tint fdim = 1 + dimensions[e.directions.out(i)];
-      result += e.position_across[i] *factor;
-      factor *= fdim;
-    }
+//  Bint factor = 1;
+//  for (unsigned int i=0;i<k;++i)
+//    {
+//      Tint fdim = dimensions[e.directions.in(i)];
+//      result += e.position_along[i] *factor;
+//      factor *= fdim;
+//    }
+//  for (unsigned int i=0;i<n-k;++i)
+//    {
+//      Tint fdim = 1 + dimensions[e.directions.out(i)];
+//      result += e.position_across[i] *factor;
+//      factor *= fdim;
+//    }
   return result;
 }
   

--- a/include/tpcc/lexicographic.h
+++ b/include/tpcc/lexicographic.h
@@ -56,9 +56,9 @@ namespace TPCC
 	  Bint p = 1;
 	  auto combination = combinations[i];
 	  for (Tint j=0;j<k;++j)
-	    p *= dimensions[combination.in(j)];
+	    p *= dimensions[n-1-combination.in(j)];
 	  for (Tint j=0;j<n-k;++j)
-	    p *= 1 + dimensions[combination.out(j)];
+	    p *= 1 + dimensions[n-1-combination.out(j)];
 	  block_sizes[i] = p;
 	}
     }
@@ -118,21 +118,20 @@ Lexicographic<n,k,Bint,Sint,Tint>::operator[] (Bint index) const
   Combinations<n,k> combinations;
   auto combination = combinations[b];
 
-  std::array<Sint, k> along;
+  std::array<Sint, n> coordinates;
   for (unsigned int i=0;i<k;++i)
     {
-      Tint fdim = dimensions[combination.in(i)];
-      along[i] = index % fdim;
+      Sint fdim = dimensions[n-1-combination.in(i)];
+      coordinates[n-1-combination.in(i)] = index % fdim;
       index /= fdim;
     }
-  std::array<Sint, n-k> across;
   for (unsigned int i=0;i<n-k;++i)
     {
-      Tint fdim = 1 + dimensions[combination.out(i)];
-      across[i] = index % fdim;
+      Sint fdim = 1 + dimensions[n-1-combination.out(i)];
+      coordinates[n-1-combination.out(i)] = index % fdim;
       index /= fdim;
     }
-  //return Element<n,k,Sint,Tint>{combination, along, across};
+  return Element<n,k,Sint,Tint>{combination, coordinates};
 }
 
 template <int n, int k, typename Bint, typename Sint, typename Tint>
@@ -141,22 +140,22 @@ Lexicographic<n,k,Bint,Sint,Tint>::index (const value_type& e) const
 {
   Bint ci = e.direction_index();
   Bint result = 0;
-//  for (unsigned int i=0;i<ci;++i)
-//    result += block_sizes[i];
+  for (unsigned int i=0;i<ci;++i)
+    result += block_sizes[i];
 
-//  Bint factor = 1;
-//  for (unsigned int i=0;i<k;++i)
-//    {
-//      Tint fdim = dimensions[e.directions.in(i)];
-//      result += e.position_along[i] *factor;
-//      factor *= fdim;
-//    }
-//  for (unsigned int i=0;i<n-k;++i)
-//    {
-//      Tint fdim = 1 + dimensions[e.directions.out(i)];
-//      result += e.position_across[i] *factor;
-//      factor *= fdim;
-//    }
+  Bint factor = 1;
+  for (Tint i=0;i<k;++i)
+    {
+      Sint fdim = dimensions[e.along_direction(i)];
+      result += e.along_coordinate(i) *factor;
+      factor *= fdim;
+    }
+  for (unsigned int i=0;i<n-k;++i)
+    {
+      Tint fdim = 1 + dimensions[e.across_direction(i)];
+      result += e.across_coordinate(i) *factor;
+      factor *= fdim;
+    }
   return result;
 }
   

--- a/include/tpcc/lexicographic.h
+++ b/include/tpcc/lexicographic.h
@@ -6,13 +6,30 @@
 namespace TPCC
 {
   /**
-   * \brief The `k`-dimensional faces in a tensor product chain complex of dimension `n`.
+   * \brief Lexicographic enumeration of the `k`-dimensional faces in a tensor product chain complex of dimension `n`.
    *
    * \tparam n: The dimension of the tensor product (the order of the tensor)
    * \tparam k: The dimensions of the object considered
    * \tparam Bint: The big integer used for addressing in the whole tensor product
-   * \tparam Sint: The small integer used for addressing in each component
-   * \tparam Tint: The tiny integer with values addressing the components
+   * \tparam Sint: The small integer used for addressing in each fiber
+   * \tparam Tint: The tiny integer with values addressing the fibers
+   *
+   * The numbering for `k==0` and `k==n` is lexicographic with the first coordinate
+   * changing fastest and the last one slowest. For `k` between those values, the set
+   * of elements consists of `n` over `k` separate sets, one for each combination of `k`
+   * different coordinates.
+   *
+   * These sets form the slowest moving part of the enumeration, and
+   * they are enumerated based such that the elements orthogonal to the first `n-k`
+   * coordinates are first, those orthogonal to the last coordinates last.
+   *
+   * The next level in the enumaration is formed by the fact that these sets
+   * can be split into 'sheets', connected sets which are not connected to each other.
+   * They are characterized by their coordinates orthogonal to the chosen `k`. Thus, their
+   * enumeration follows a lexicographic scheme with first fastest for these coordinates.
+   *
+   * The fastes level of enumeration is inside each sheet, where again the first coordinates
+   * run fastest.
    */
   template <int n, int k, typename Bint = unsigned int, typename Sint = unsigned short, typename Tint = unsigned char>
   class Lexicographic

--- a/tests/element_01.cc
+++ b/tests/element_01.cc
@@ -3,8 +3,8 @@
 
 #include <tpcc/element.h>
 
-template <int n, int k, typename T>
-void test(const TPCC::Element<n,k,T>& e)
+template <int n, int k, typename T1, typename T2>
+void test(const TPCC::Element<n,k,T1,T2>& e)
 {
     e.print_debug(std::cout);
 
@@ -37,14 +37,11 @@ template <int n, int k>
 void test()
 {
     TPCC::Combinations<n,k> combinations;
-    std::array<unsigned int, k> along;
-    for (unsigned int i=0;i<k;++i)
-        along[i] = fibonacci(k+i);
-    std::array<unsigned int, n-k> across;
-    for (unsigned int i=0;i<n-k;++i)
-        across[i] = fibonacci(n+i);
+    std::array<unsigned int, n> positions;
+    for (unsigned int i=0;i<n;++i)
+        positions[i] = fibonacci(k+i);
 
-    TPCC::Element<n,k,unsigned int> e{combinations[combinations.size()/3], along, across};
+    TPCC::Element<n,k,unsigned int, unsigned short> e{combinations[combinations.size()/3], positions};
     test(e);
 }
 

--- a/tests/lexicographic_01.cc
+++ b/tests/lexicographic_01.cc
@@ -1,4 +1,4 @@
-// Unit tests:
+// Unit test:
 // Lexicographic::size()
 // Lexicographic::block_size()
 
@@ -11,13 +11,13 @@
 const unsigned int size2[] = { 12, 17, 6};
 const unsigned int size3[] = { 60, 133, 98, 24 };
 const unsigned int block_sizes20[] = { 12 };
-const unsigned int block_sizes21[] = { 8,9 };
+const unsigned int block_sizes21[] = { 9, 8 };
 const unsigned int block_sizes22[] = { 6 };
 const unsigned int *block_sizes2[] =
 { block_sizes20, block_sizes21, block_sizes22 };
 const unsigned int block_sizes30[] = { 60 };
-const unsigned int block_sizes31[] = { 40,45,48 };
-const unsigned int block_sizes32[] = { 30,32,36 };
+const unsigned int block_sizes31[] = { 48,45,40 };
+const unsigned int block_sizes32[] = { 36,32,30 };
 const unsigned int block_sizes33[] = { 24 };
 const unsigned int *block_sizes3[] =
 { block_sizes30, block_sizes31, block_sizes32, block_sizes33 };

--- a/tests/lexicographic_02.cc
+++ b/tests/lexicographic_02.cc
@@ -1,3 +1,7 @@
+// Unit test:
+// Lexicographic::index()
+// Lexicographic::operator[]
+
 #include <iostream>
 #include <iomanip>
 

--- a/tests/lexicographic_03.cc
+++ b/tests/lexicographic_03.cc
@@ -21,16 +21,12 @@ void print_mesh(const TPCC::Lexicographic<n,k>& mesh)
     {
       auto element = mesh[i];
       std::cout << std::setw(4) << i << " {";
-      element.print_debug(std::cout);
-      std::cout << "\n";
       for (unsigned int i=0;i<element.n_facets();++i)
         {
           element.facet(i).print_debug(std::cout);
           std::cout << std::setw(4)
                     <<  boundary.index(element.facet(i))
                     << ",";
-          std::cout << "\n";
-
         }
 
       std::cout << " }," << std::endl;


### PR DESCRIPTION
Change the layout of coordinates in Element to a flat array of size n. Also revert the order of combinations, such that smallest indices move fastest.